### PR TITLE
Replacement of APM usage (Begin/EndGetResponse, etc.) with TAP and async/await

### DIFF
--- a/trello/packages.config
+++ b/trello/packages.config
@@ -3,6 +3,9 @@
   <package id="BugSense.WP8" version="3.4" targetFramework="wp80" />
   <package id="Caliburn.Micro" version="1.5.2" targetFramework="wp80" />
   <package id="JetBrains.Annotations" version="7.0" targetFramework="wp80" />
+  <package id="Microsoft.Bcl" version="1.1.3" targetFramework="wp80" />
+  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="wp80" />
+  <package id="Microsoft.Net.Http" version="2.2.13" targetFramework="wp80" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="wp80" />
   <package id="RestSharp" version="104.1" targetFramework="wp80" />
   <package id="ServiceStack.Text" version="3.9.54" targetFramework="wp80" />

--- a/trello/trello.csproj
+++ b/trello/trello.csproj
@@ -573,6 +573,15 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\ServiceStack.Text.3.9.54\lib\sl4-windowsphone71\ServiceStack.Text.WP.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.13\lib\sl4-windowsphone71\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.13\lib\sl4-windowsphone71\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.13\lib\sl4-windowsphone71\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Interactivity, Version=3.9.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.1.5.2\lib\wp8\System.Windows.Interactivity.dll</HintPath>
     </Reference>


### PR DESCRIPTION
As part of a research project at the University of Illinois at Urbana-Champaign, we're developing a refactoring tool that replaces instances of the APM pattern with corresponding TAP method calls and the async/await keywords. I've applied it to this project.

This pull request replaces those existing calls to APM Begin/End\* methods with functionally equivalent TAP constructs and the async/await keywords. It decreases the code complexity a lot. 

I also added a dependency that is needed: HttpClient library by Microsoft (this library will be in Windows Phone 8 SDK soon after an update).

Are you interested in merging this pull request? If not, please let me know why, and I'll try and improve the pull request with your comments in mind.

Thanks for your time,
Semih Okur
