### PR TITLE
Removed unnecessary async/await keywords

### DIFF
--- a/trello/Services/Cache/ProgressAwareRestClient.cs
+++ b/trello/Services/Cache/ProgressAwareRestClient.cs
@@ -18,26 +18,26 @@ namespace trello.Services.Cache
             _progress = progress;
         }
 
-        public async Task<IRestResponse> RequestAsync(IRestRequest request)
+        public Task<IRestResponse> RequestAsync(IRestRequest request)
         {
             using (new ProgressScope(_progress, GetMessageFor(request)))
             {
-                return await _client.RequestAsync(request);
+                return _client.RequestAsync(request);
             }
         }
 
-        public async Task<T> RequestAsync<T>(IRestRequest request) where T : class, new()
+        public Task<T> RequestAsync<T>(IRestRequest request) where T : class, new()
         {
             using (new ProgressScope(_progress, GetMessageFor(request)))
             {
-                return await _client.RequestAsync<T>(request);
+                return _client.RequestAsync<T>(request);
             }
         }
 
-        public async Task<IEnumerable<T>> RequestListAsync<T>(IRestRequest request)
+        public Task<IEnumerable<T>> RequestListAsync<T>(IRestRequest request)
         {
             using (new ProgressScope(_progress, GetMessageFor(request)))
-                return await _client.RequestListAsync<T>(request);
+                return _client.RequestListAsync<T>(request);
         }
 
         public Task<Uri> GetAuthorizationUri(string applicationName, Scope scope, Expiration expiration, Uri callbackUri = null)


### PR DESCRIPTION
I am a PhD student in the CS department at the University of Illinois. I'm currently doing research on asynchronous programming in phone applications. I developed a tool that automatically improves async/await usages by doing transformations.

The tool found some opportunities in your application. There was no need to use async/await for 3 methods. It will decrease the overhead that is caused by async/await state machine and it will simplify the code. Removing async/await does not change the behavior at all.

Are you interested in merging this pull request? If not, please let me know why.

Thanks for your time,
